### PR TITLE
Feature/#2 internセクションへの経歴追加

### DIFF
--- a/components/Intern/Career.tsx
+++ b/components/Intern/Career.tsx
@@ -1,0 +1,21 @@
+import { CareerProps } from "./Career.type";
+
+const Career = ({ companyName, role, fromDate, untilDate }: CareerProps) => {
+  return (
+    <li className="flex gap-4">
+      <dl className="flex flex-wrap flex-auto gap-x-2">
+        <dt className="sr-only">Company</dt>
+        <dd className="flex-none w-full text-lg">{companyName}</dd>
+        <dt className="sr-only">Role</dt>
+        <dd className="text-sm text-gray-400">{role}</dd>
+        <dd className="ml-auto text-sm text-gray-400">
+          <time dateTime={fromDate}>{fromDate}</time>
+          <span> - </span>
+          <time dateTime={untilDate}>{untilDate}</time>
+        </dd>
+      </dl>
+    </li>
+  );
+};
+
+export default Career;

--- a/components/Intern/Career.type.ts
+++ b/components/Intern/Career.type.ts
@@ -1,0 +1,6 @@
+export type CareerProps = {
+  companyName: string;
+  role: string;
+  fromDate: string;
+  untilDate: string;
+};

--- a/components/Intern/intern-history.ts
+++ b/components/Intern/intern-history.ts
@@ -1,0 +1,16 @@
+import { CareerProps } from "./Career.type";
+
+export const internHistory: CareerProps[] = [
+  {
+    companyName: "フェンリル株式会社",
+    role: "ウェブエンジニアコース",
+    fromDate: "2022/09/05",
+    untilDate: "2022/09/09",
+  },
+  {
+    companyName: "チームラボ株式会社",
+    role: "Webアプリエンジニア",
+    fromDate: "2022/08/22",
+    untilDate: "2022/09/02",
+  },
+];

--- a/components/Intern/intern-history.ts
+++ b/components/Intern/intern-history.ts
@@ -2,6 +2,12 @@ import { CareerProps } from "./Career.type";
 
 export const internHistory: CareerProps[] = [
   {
+    companyName: "株式会社80&Company",
+    role: "Technology Consulting 部 (フロントエンド)",
+    fromDate: "2022/12/01",
+    untilDate: "現在",
+  },
+  {
     companyName: "フェンリル株式会社",
     role: "ウェブエンジニアコース",
     fromDate: "2022/09/05",

--- a/components/InternSection.tsx
+++ b/components/InternSection.tsx
@@ -1,38 +1,15 @@
 import React from "react";
+import Career from "./Intern/Career";
+import { internHistory } from "./Intern/intern-history";
 
 const InternSection: React.FC = () => {
   return (
     <section className="mb-12">
       <h1 className="mb-8 text-4xl font-bold text-center">Intern</h1>
       <ol className="space-y-4">
-        <li className="flex gap-4">
-          {/* fenrir */}
-          <dl className="flex flex-wrap flex-auto gap-x-2">
-            <dt className="sr-only">Company</dt>
-            <dd className="flex-none w-full text-lg">フェンリル株式会社</dd>
-            <dt className="sr-only">Role</dt>
-            <dd className="text-sm text-gray-400">ウェブエンジニアコース</dd>
-            <dd className="ml-auto text-sm text-gray-400">
-              <time dateTime="2022-08-22">2022/09/05</time>
-              <span> - </span>
-              <time dateTime="2022-09-02">2022/09/09</time>
-            </dd>
-          </dl>
-        </li>
-        {/* team-lab */}
-        <li className="flex gap-4">
-          <dl className="flex flex-wrap flex-auto gap-x-2">
-            <dt className="sr-only">Company</dt>
-            <dd className="flex-none w-full text-lg">チームラボ株式会社</dd>
-            <dt className="sr-only">Role</dt>
-            <dd className="text-sm text-gray-400">Webアプリエンジニア</dd>
-            <dd className="ml-auto text-sm text-gray-400">
-              <time dateTime="2022-08-22">2022/08/22</time>
-              <span> - </span>
-              <time dateTime="2022-09-02">2022/09/02</time>
-            </dd>
-          </dl>
-        </li>
+        {internHistory.map((history) => (
+          <Career {...history} key={history.companyName} />
+        ))}
       </ol>
     </section>
   );


### PR DESCRIPTION
## Issue
- #2 

## なぜやるのか

- 長期インターンに新しく参加したため経歴を追加したい
- 経歴をコンポーネント化することで今後の経歴の追加を容易にしたい

## なにをやったのか

- 経歴をコンポーネント化
- これまでのインターン経歴をオブジェクトの配列として管理するようにした
- 経歴に長期インターンを追加した 